### PR TITLE
Add support for Advanced Mobile Device Searches

### DIFF
--- a/get-token.sh
+++ b/get-token.sh
@@ -655,14 +655,15 @@ get_api_object_type() {
     local api_xml_object=$1
 
     case "$api_xml_object" in
-        advanced_computer_search)   api_object_type="advancedcomputersearches";;
-        category)                   api_object_type="categories";;
-        configuration_profile)      api_object_type="mobiledeviceconfigurationprofiles";;
-        ebook)                      api_object_type="ebooks";;
-        group|user)                 api_object_type="accounts";;
-        policy)                     api_object_type="policies";;
-        restricted_software_title)  api_object_type="restrictedsoftware";;
-        *)                          api_object_type=$( echo "${api_xml_object}s" | sed 's|_||g' );;
+        advanced_computer_search)        api_object_type="advancedcomputersearches";;
+        advanced_mobile_device_search)   api_object_type="advancedmobiledevicesearches";;
+        category)                        api_object_type="categories";;
+        configuration_profile)           api_object_type="mobiledeviceconfigurationprofiles";;
+        ebook)                           api_object_type="ebooks";;
+        group|user)                      api_object_type="accounts";;
+        policy)                          api_object_type="policies";;
+        restricted_software_title)       api_object_type="restrictedsoftware";;
+        *)                               api_object_type=$( echo "${api_xml_object}s" | sed 's|_||g' );;
     esac
     echo "$api_object_type"
 }
@@ -671,11 +672,12 @@ get_plural_from_api_xml_object() {
     local api_xml_object=$1
 
     case "$api_xml_object" in
-        advanced_computer_search)   api_xml_object_plural="advanced_computer_searches";;
-        category)                   api_xml_object_plural="categories";;
-        policy)                     api_xml_object_plural="policies";;
-        restricted_software_title)  api_xml_object_plural="restricted_software";;
-        *)                          api_xml_object_plural="${api_xml_object}s"
+        advanced_computer_search)        api_xml_object_plural="advanced_computer_searches";;
+        advanced_mobile_device_search)   api_xml_object_plural="advanced_mobile_device_searches";;
+        category)                        api_xml_object_plural="categories";;
+        policy)                          api_xml_object_plural="policies";;
+        restricted_software_title)       api_xml_object_plural="restricted_software";;
+        *)                               api_xml_object_plural="${api_xml_object}s"
     esac
     echo "$api_xml_object_plural"
 }

--- a/jocads.sh
+++ b/jocads.sh
@@ -1435,6 +1435,7 @@ main() {
         echo
         echo "API object type options:"
         echo "   A - [A]dvanced Computer Search"
+        echo "   B - Advanced Mo[b]ile Device Search"
         echo "   C - [C]onfiguration Profile"
         echo "   F - Configuration Profile - [f]ix Payload Organisation"
         echo "   O - Configuration Profile - specify UUID to rescue [o]rphaned profile"
@@ -1455,6 +1456,9 @@ main() {
         case "$api_object_type_request" in
             A|a)
                 api_xml_object="advanced_computer_search"
+            ;;
+            B|b)
+                api_xml_object="advanced_mobile_device_search"
             ;;
             G|g)
                 api_xml_object="computer_group"


### PR DESCRIPTION
Adds the option to work with Advanced Mobile Device Searches.

Option presented as follows when running `jocads.sh`

```
   B - Advanced Mo[b]ile Device Search
```