### PR TITLE
Update _common-framework.sh

### DIFF
--- a/_common-framework.sh
+++ b/_common-framework.sh
@@ -82,7 +82,7 @@ get_slack_webhook() {
 get_instance_list_files() {
     # get a list of instance list files
     # import relevant instance list
-    default_instance_lists_folder="$this_script_dir/instance-lists"
+    instance_lists_folder="$this_script_dir/instance-lists"
     if defaults read com.github.autopkg instance_lists &>/dev/null; then
         instance_lists_folder=$(defaults read com.github.autopkg instance_lists)
         echo "Instance lists folder: $instance_lists_folder"
@@ -101,9 +101,9 @@ get_instance_list_files() {
     fi
 
     # repeat for the default in case we need to keep private lists
-    if [[ -d "$default_instance_lists_folder" ]] && [[ $(find "$default_instance_lists_folder" -type f -name "*.txt" -not -name "default-instance-list.txt" -maxdepth 1 2>/dev/null | wc -l) -gt 0 ]]; then
+    if [[ -d "$instance_lists_folder" ]] && [[ $(find "$instance_lists_folder" -type f -name "*.txt" -not -name "default-instance-list.txt" -maxdepth 1 2>/dev/null | wc -l) -gt 0 ]]; then
         echo
-        echo "Private Instance lists folder: $default_instance_lists_folder"
+        echo "Private Instance lists folder: $instance_lists_folder"
         echo
         while IFS= read -r -d '' file; do
             filename=$(basename "$file" | cut -d. -f 1)
@@ -118,7 +118,7 @@ get_instance_list_files() {
                 echo "[$i] $filename"
                 ((i++))
             fi
-        done < <(find "$default_instance_lists_folder" -type f -name "*.txt" -not -name "default-instance-list.txt" -print0)
+        done < <(find "$instance_lists_folder" -type f -name "*.txt" -not -name "default-instance-list.txt" -print0)
     fi
     if [[ $i -eq 0 ]]; then
         echo


### PR DESCRIPTION
This addresses an issue whereby if `instance_lists` is not set in `com.github.autopkg`, an "Instance list not found" error would present after instance list selection, when specifying a desired instance list from the list of lists.

Now, behaviour works as expected:

* If `instance_lists` is not set in `com.github.autopkg`, instance list selection offers lists from `$this_script_dir/instance-lists`, the chosen instance list is parsed and used.
* If `instance_lists` is set in `com.github.autopkg`, instance list selection offers lists from the path specified in that preference key, the chosen instance list is parsed and used.