### PR TITLE
don't send credentials to autopkg

### DIFF
--- a/_common-framework.sh
+++ b/_common-framework.sh
@@ -797,10 +797,10 @@ run_jamfupload() {
     instance_args+=("$jss_instance")
 
     # add the credentials
-    instance_args+=("--user")
-    instance_args+=("$jss_api_user")
-    instance_args+=("--pass")
-    instance_args+=("$jss_api_password")
+    # instance_args+=("--user")
+    # instance_args+=("$jss_api_user")
+    # instance_args+=("--pass")
+    # instance_args+=("$jss_api_password")
 
     # determine the share
     if element_in "pkg" "${args[@]}" || element_in "package" "${args[@]}"; then
@@ -830,7 +830,6 @@ run_jamfupload() {
 encode_name() {
     group_name_encoded="$( echo "$1" | sed -e 's| |%20|g' | sed -e 's|&amp;|%26|g' )"
 }
-
 
 get_object_id_from_name() {
     set_credentials "$jss_instance"

--- a/autopkg-run.sh
+++ b/autopkg-run.sh
@@ -44,10 +44,10 @@ run_autopkg() {
     autopkg_run_options+=("JSS_URL=$jss_instance")
 
     # add the credentials
-    autopkg_run_options+=("--key")
-    autopkg_run_options+=("API_USERNAME=$jss_api_user")
-    autopkg_run_options+=("--key")
-    autopkg_run_options+=("API_PASSWORD=$jss_api_password")
+    # autopkg_run_options+=("--key")
+    # autopkg_run_options+=("API_USERNAME=$jss_api_user")
+    # autopkg_run_options+=("--key")
+    # autopkg_run_options+=("API_PASSWORD=$jss_api_password")
 
     # temporarily clear any API clients in the AutoPkg prefs
     autopkg_run_options+=("--key")


### PR DESCRIPTION
JamfUploader can now grab credentials directly from the keychain, so there's no more reason to add them to the autopkg commands in jamfuploader-run and autopkg-run.